### PR TITLE
Do not wrap `paused` and `delete` Cron options into `events`

### DIFF
--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -496,10 +496,10 @@ defmodule AshOban do
           opts =
             case trigger.state do
               :paused ->
-                [events: [paused: true]]
+                [paused: true]
 
               :deleted ->
-                [events: [delete: true]]
+                [delete: true]
 
               _ ->
                 []


### PR DESCRIPTION
It breaks the application boot by throwing an irrelevant error.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
