### PR TITLE
Fix/v0.2.3.rc.0 oban pro configuration

### DIFF
--- a/documentation/tutorials/get-started-with-ash-oban.md
+++ b/documentation/tutorials/get-started-with-ash-oban.md
@@ -49,8 +49,6 @@ Next, allow AshOban to alter your configuration in your Application module:
 
 # With this
 {Oban, AshOban.config(Application.fetch_env!(:my_app, :ash_domains), your_oban_config)}
-# OR this, if you are using Oban Pro
-{Oban, AshOban.config(Application.fetch_env!(:my_app, :ash_domains), your_oban_config, pro?: true)}
 # OR this, to selectively enable AshOban only for specific domains
 {Oban, AshOban.config([YourDomain, YourOtherDomain], your_oban_config)}
 ```

--- a/documentation/tutorials/get-started-with-ash-oban.md
+++ b/documentation/tutorials/get-started-with-ash-oban.md
@@ -49,6 +49,8 @@ Next, allow AshOban to alter your configuration in your Application module:
 
 # With this
 {Oban, AshOban.config(Application.fetch_env!(:my_app, :ash_domains), your_oban_config)}
+# OR this, if you are using Oban Pro
+{Oban, AshOban.config(Application.fetch_env!(:my_app, :ash_domains), your_oban_config, pro?: true)}
 # OR this, to selectively enable AshOban only for specific domains
 {Oban, AshOban.config([YourDomain, YourOtherDomain], your_oban_config)}
 ```

--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -548,7 +548,7 @@ defmodule AshOban do
     if (pro_dynamic_cron_plugin? || pro_dynamic_queues_plugin?) && base[:engine] not in [Oban.Pro.Queue.SmartEngine, Oban.Pro.Engines.Smart] do
       raise """
       Expected oban engine to be Oban.Pro.Queue.SmartEngine or Oban.Pro.Engines.Smart, but got #{inspect(base[:engine])}.
-      This expectation is because you're using almost one Oban.Pro's plugin`.
+      This expectation is because you're using at least one Oban.Pro plugin`.
       """
     end
 

--- a/test/ash_oban_test.exs
+++ b/test/ash_oban_test.exs
@@ -80,4 +80,46 @@ defmodule AshObanTest do
              ]
            ] = config
   end
+
+  test "oban pro configuration" do
+    config =
+      AshOban.config([Domain], [
+        engine: Oban.Pro.Engines.Smart,
+        plugins: [
+          {Oban.Pro.Plugins.DynamicCron, [
+            timezone: "Europe/Rome",
+            sync_mode: :automatic,
+            crontab: []
+          ]},
+          {Oban.Pro.Plugins.DynamicQueues,
+            queues: [
+              triggered_process: 10,
+              triggered_process_2: 10,
+              triggered_say_hello: 10
+            ]}
+        ],
+        queues: false
+      ], pro?: true)
+
+    assert [
+              engine: Oban.Pro.Engines.Smart,
+              plugins: [
+                {Oban.Pro.Plugins.DynamicCron, [
+                  timezone: "Europe/Rome",
+                  sync_mode: :automatic,
+                  crontab: [
+                    {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello, []},
+                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process, []}
+                  ]
+                ]},
+                {Oban.Pro.Plugins.DynamicQueues,
+                queues: [
+                  triggered_process: 10,
+                  triggered_process_2: 10,
+                  triggered_say_hello: 10
+                ]}
+              ],
+              queues: false
+            ] = config
+    end
 end

--- a/test/ash_oban_test.exs
+++ b/test/ash_oban_test.exs
@@ -99,7 +99,7 @@ defmodule AshObanTest do
             ]}
         ],
         queues: false
-      ], pro?: true)
+      ])
 
     assert [
               engine: Oban.Pro.Engines.Smart,


### PR DESCRIPTION
Hi @zachdaniel,
using this extension with Oban Pro while Oban.Pro.Plugins.DynamicQueues is used for queues configuration raise an error.

I've fixed here for the new v0.2.3 and [here](https://github.com/zoonect-oss/ash_oban/tree/fix/v0.2.2-oban-pro-configuration) for the v0.2.2 (pre Ash 3.0) but it seems I can't directly create another pull request with that specific tag as target.

### Contributor checklist

- [X] Features include unit/acceptance tests
