### PR TITLE
Fix/main state active

### DIFF
--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -537,7 +537,6 @@ defmodule AshOban do
       |> Keyword.get(:plugins, [])
       |> Enum.any?(fn {plugin, _opts} -> plugin == Oban.Pro.Plugins.DynamicQueues end)
 
-
     cron_plugin =
       if pro_dynamic_cron_plugin? do
         Oban.Pro.Plugins.DynamicCron
@@ -545,7 +544,8 @@ defmodule AshOban do
         Oban.Plugins.Cron
       end
 
-    if (pro_dynamic_cron_plugin? || pro_dynamic_queues_plugin?) && base[:engine] not in [Oban.Pro.Queue.SmartEngine, Oban.Pro.Engines.Smart] do
+    if (pro_dynamic_cron_plugin? || pro_dynamic_queues_plugin?) &&
+         base[:engine] not in [Oban.Pro.Queue.SmartEngine, Oban.Pro.Engines.Smart] do
       raise """
       Expected oban engine to be Oban.Pro.Queue.SmartEngine or Oban.Pro.Engines.Smart, but got #{inspect(base[:engine])}.
       This expectation is because you're using at least one Oban.Pro plugin`.
@@ -649,7 +649,9 @@ defmodule AshOban do
       config[:plugins]
       |> Enum.find({nil, nil}, fn {plugin, _opts} -> plugin == Oban.Pro.Plugins.DynamicQueues end)
 
-    if !is_list(plugin_config) || !Keyword.has_key?(plugin_config, :queues) || !is_list(plugin_config[:queues]) || !Keyword.has_key?(plugin_config[:queues], trigger.queue) do
+    if !is_list(plugin_config) || !Keyword.has_key?(plugin_config, :queues) ||
+         !is_list(plugin_config[:queues]) ||
+         !Keyword.has_key?(plugin_config[:queues], trigger.queue) do
       raise """
       Must configure the queue `:#{trigger.queue}`, required for
       the trigger `:#{trigger.name}` on #{inspect(resource)}

--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -595,12 +595,15 @@ defmodule AshOban do
       Enum.map(plugins, fn
         {^cron_plugin, config} ->
           opts =
-            case trigger.state do
-              :paused ->
+            case {cron_plugin, trigger.state} do
+              {_cron_plugin, :paused} ->
                 [paused: true]
 
-              :deleted ->
+              {_cron_plugin, :deleted} ->
                 [delete: true]
+
+              {Oban.Pro.Plugins.DynamicCron, :active} ->
+                [paused: false]
 
               _ ->
                 []

--- a/test/ash_oban_test.exs
+++ b/test/ash_oban_test.exs
@@ -83,43 +83,47 @@ defmodule AshObanTest do
 
   test "oban pro configuration" do
     config =
-      AshOban.config([Domain], [
+      AshOban.config([Domain],
         engine: Oban.Pro.Engines.Smart,
         plugins: [
-          {Oban.Pro.Plugins.DynamicCron, [
-            timezone: "Europe/Rome",
-            sync_mode: :automatic,
-            crontab: []
-          ]},
+          {Oban.Pro.Plugins.DynamicCron,
+           [
+             timezone: "Europe/Rome",
+             sync_mode: :automatic,
+             crontab: []
+           ]},
           {Oban.Pro.Plugins.DynamicQueues,
-            queues: [
-              triggered_process: 10,
-              triggered_process_2: 10,
-              triggered_say_hello: 10
-            ]}
+           queues: [
+             triggered_process: 10,
+             triggered_process_2: 10,
+             triggered_say_hello: 10
+           ]}
         ],
         queues: false
-      ])
+      )
 
     assert [
-              engine: Oban.Pro.Engines.Smart,
-              plugins: [
-                {Oban.Pro.Plugins.DynamicCron, [
+             engine: Oban.Pro.Engines.Smart,
+             plugins: [
+               {Oban.Pro.Plugins.DynamicCron,
+                [
                   timezone: "Europe/Rome",
                   sync_mode: :automatic,
                   crontab: [
-                    {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello, [paused: false]},
-                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process, [paused: false]}
+                    {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello,
+                     [paused: false]},
+                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process,
+                     [paused: false]}
                   ]
                 ]},
-                {Oban.Pro.Plugins.DynamicQueues,
+               {Oban.Pro.Plugins.DynamicQueues,
                 queues: [
                   triggered_process: 10,
                   triggered_process_2: 10,
                   triggered_say_hello: 10
                 ]}
-              ],
-              queues: false
-            ] = config
-    end
+             ],
+             queues: false
+           ] = config
+  end
 end

--- a/test/ash_oban_test.exs
+++ b/test/ash_oban_test.exs
@@ -108,8 +108,8 @@ defmodule AshObanTest do
                   timezone: "Europe/Rome",
                   sync_mode: :automatic,
                   crontab: [
-                    {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello, []},
-                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process, []}
+                    {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello, [paused: false]},
+                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process, [paused: false]}
                   ]
                 ]},
                 {Oban.Pro.Plugins.DynamicQueues,


### PR DESCRIPTION
With ObanPro and the DynamicQueues plugin, when a queue is paused with "paused: true", it's not enough to simply remove "paused: true" from the configuration to restart it, but it's necessary to specify "paused: false".

### Contributor checklist

- [X] Features include unit/acceptance tests
