### PR TITLE
Fix/2.0 state active

### DIFF
--- a/documentation/tutorials/get-started-with-ash-oban.md
+++ b/documentation/tutorials/get-started-with-ash-oban.md
@@ -49,8 +49,6 @@ Next, allow AshOban to alter your configuration in your Application module:
 
 # With this
 {Oban, AshOban.config(Application.fetch_env!(:my_app, :ash_apis), your_oban_config)}
-# OR this, if you are using Oban Pro
-{Oban, AshOban.config(Application.fetch_env!(:my_app, :ash_apis), your_oban_config, pro?: true)}
 # OR this, to selectively enable AshOban only for specific APIs
 {Oban, AshOban.config([YourApi, YourOtherApi], your_oban_config)}
 ```

--- a/documentation/tutorials/get-started-with-ash-oban.md
+++ b/documentation/tutorials/get-started-with-ash-oban.md
@@ -49,6 +49,8 @@ Next, allow AshOban to alter your configuration in your Application module:
 
 # With this
 {Oban, AshOban.config(Application.fetch_env!(:my_app, :ash_apis), your_oban_config)}
+# OR this, if you are using Oban Pro
+{Oban, AshOban.config(Application.fetch_env!(:my_app, :ash_apis), your_oban_config, pro?: true)}
 # OR this, to selectively enable AshOban only for specific APIs
 {Oban, AshOban.config([YourApi, YourOtherApi], your_oban_config)}
 ```

--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -546,7 +546,8 @@ defmodule AshOban do
         Oban.Plugins.Cron
       end
 
-    if (pro_dynamic_cron_plugin? || pro_dynamic_queues_plugin?) && base[:engine] not in [Oban.Pro.Queue.SmartEngine, Oban.Pro.Engines.Smart] do
+    if (pro_dynamic_cron_plugin? || pro_dynamic_queues_plugin?) &&
+         base[:engine] not in [Oban.Pro.Queue.SmartEngine, Oban.Pro.Engines.Smart] do
       raise """
       Expected oban engine to be Oban.Pro.Queue.SmartEngine or Oban.Pro.Engines.Smart, but got #{inspect(base[:engine])}.
       This expectation is because you're using at least one Oban.Pro plugin`.
@@ -650,7 +651,9 @@ defmodule AshOban do
       config[:plugins]
       |> Enum.find({nil, nil}, fn {plugin, _opts} -> plugin == Oban.Pro.Plugins.DynamicQueues end)
 
-    if !is_list(plugin_config) || !Keyword.has_key?(plugin_config, :queues) || !is_list(plugin_config[:queues]) || !Keyword.has_key?(plugin_config[:queues], trigger.queue) do
+    if !is_list(plugin_config) || !Keyword.has_key?(plugin_config, :queues) ||
+         !is_list(plugin_config[:queues]) ||
+         !Keyword.has_key?(plugin_config[:queues], trigger.queue) do
       raise """
       Must configure the queue `:#{trigger.queue}`, required for
       the trigger `:#{trigger.name}` on #{inspect(resource)}

--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -596,12 +596,15 @@ defmodule AshOban do
       Enum.map(plugins, fn
         {^cron_plugin, config} ->
           opts =
-            case trigger.state do
-              :paused ->
+            case {cron_plugin, trigger.state} do
+              {_cron_plugin, :paused} ->
                 [paused: true]
 
-              :deleted ->
+              {_cron_plugin, :deleted} ->
                 [delete: true]
+
+              {Oban.Pro.Plugins.DynamicCron, :active} ->
+                [paused: false]
 
               _ ->
                 []

--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -549,7 +549,7 @@ defmodule AshOban do
     if (pro_dynamic_cron_plugin? || pro_dynamic_queues_plugin?) && base[:engine] not in [Oban.Pro.Queue.SmartEngine, Oban.Pro.Engines.Smart] do
       raise """
       Expected oban engine to be Oban.Pro.Queue.SmartEngine or Oban.Pro.Engines.Smart, but got #{inspect(base[:engine])}.
-      This expectation is because you're using almost one Oban.Pro's plugin`.
+      This expectation is because you're using at least one Oban.Pro plugin`.
       """
     end
 

--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -515,6 +515,13 @@ defmodule AshOban do
       Whether to require queues and plugins to be defined in your oban config. This can be helpful to
       allow the ability to split queues between nodes. See https://hexdocs.pm/oban/splitting-queues.html
       """
+    ],
+    pro?: [
+      type: :boolean,
+      default: false,
+      doc: """
+      If you are using Oban Pro, set this to true
+      """
     ]
   ]
 
@@ -528,19 +535,18 @@ defmodule AshOban do
   def config(apis, base, opts \\ []) do
     apis = List.wrap(apis)
     opts = Spark.OptionsHelpers.validate!(opts, @config_schema)
-    pro? = AshOban.Info.pro?()
 
     cron_plugin =
-      if pro? do
+      if opts[:pro?] do
         Oban.Pro.Plugins.DynamicCron
       else
         Oban.Plugins.Cron
       end
 
-    if pro? && base[:engine] not in [Oban.Pro.Queue.SmartEngine, Oban.Pro.Engines.Smart] do
+    if opts[:pro?] && base[:engine] not in [Oban.Pro.Queue.SmartEngine, Oban.Pro.Engines.Smart] do
       raise """
       Expected oban engine to be Oban.Pro.Queue.SmartEngine or Oban.Pro.Engines.Smart, but got #{inspect(base[:engine])}.
-      This expectation is because you've set `config :ash_oban, pro?: true`.
+      This expectation is because you've called AshOban.config\3 with `pro?: true`.
       """
     end
 
@@ -555,7 +561,7 @@ defmodule AshOban do
       |> AshOban.Info.oban_triggers_and_scheduled_actions()
       |> tap(fn triggers ->
         if opts[:require?] do
-          Enum.each(triggers, &require_queues!(base, resource, &1))
+          Enum.each(triggers, &require_queues!(base, resource, opts[:pro?], &1))
         end
       end)
       |> Enum.filter(fn
@@ -615,7 +621,7 @@ defmodule AshOban do
     end)
   end
 
-  defp require_queues!(config, resource, trigger) do
+  defp require_queues!(config, resource, false, trigger) do
     unless config[:queues][trigger.queue] do
       raise """
       Must configure the queue `:#{trigger.queue}`, required for
@@ -625,6 +631,35 @@ defmodule AshOban do
 
     if Map.has_key?(trigger, :scheduler_queue) do
       unless config[:queues][trigger.scheduler_queue] do
+        raise """
+        Must configure the queue `:#{trigger.scheduler_queue}`, required for
+        the scheduler of the trigger `:#{trigger.name}` on #{inspect(resource)}
+        """
+      end
+    end
+  end
+
+  defp require_queues!(config, resource, true, trigger) do
+    {_plugin_name, plugin_config} =
+      config[:plugins]
+      |> Enum.find({nil, nil}, fn {plugin, _opts} -> plugin == Oban.Pro.Plugins.DynamicQueues end)
+
+    if !is_list(plugin_config) || !Keyword.has_key?(plugin_config, :queues) || !is_list(plugin_config[:queues]) || !Keyword.has_key?(plugin_config[:queues], trigger.queue) do
+      raise """
+      Must configure the queue `:#{trigger.queue}`, required for
+      the trigger `:#{trigger.name}` on #{inspect(resource)}
+      """
+    end
+
+    if !is_nil(config[:queues]) && config[:queues] != false do
+      raise """
+      Must configure the queue through Oban.Pro.Plugins.DynamicQueues plugin
+      when Oban Pro is used
+      """
+    end
+
+    if Map.has_key?(trigger, :scheduler_queue) do
+      unless plugin_config[:queues][trigger.scheduler_queue] do
         raise """
         Must configure the queue `:#{trigger.scheduler_queue}`, required for
         the scheduler of the trigger `:#{trigger.name}` on #{inspect(resource)}

--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -515,13 +515,6 @@ defmodule AshOban do
       Whether to require queues and plugins to be defined in your oban config. This can be helpful to
       allow the ability to split queues between nodes. See https://hexdocs.pm/oban/splitting-queues.html
       """
-    ],
-    pro?: [
-      type: :boolean,
-      default: false,
-      doc: """
-      If you are using Oban Pro, set this to true
-      """
     ]
   ]
 
@@ -536,17 +529,27 @@ defmodule AshOban do
     apis = List.wrap(apis)
     opts = Spark.OptionsHelpers.validate!(opts, @config_schema)
 
+    pro_dynamic_cron_plugin? =
+      base
+      |> Keyword.get(:plugins, [])
+      |> Enum.any?(fn {plugin, _opts} -> plugin == Oban.Pro.Plugins.DynamicCron end)
+
+    pro_dynamic_queues_plugin? =
+      base
+      |> Keyword.get(:plugins, [])
+      |> Enum.any?(fn {plugin, _opts} -> plugin == Oban.Pro.Plugins.DynamicQueues end)
+
     cron_plugin =
-      if opts[:pro?] do
+      if pro_dynamic_cron_plugin? do
         Oban.Pro.Plugins.DynamicCron
       else
         Oban.Plugins.Cron
       end
 
-    if opts[:pro?] && base[:engine] not in [Oban.Pro.Queue.SmartEngine, Oban.Pro.Engines.Smart] do
+    if (pro_dynamic_cron_plugin? || pro_dynamic_queues_plugin?) && base[:engine] not in [Oban.Pro.Queue.SmartEngine, Oban.Pro.Engines.Smart] do
       raise """
       Expected oban engine to be Oban.Pro.Queue.SmartEngine or Oban.Pro.Engines.Smart, but got #{inspect(base[:engine])}.
-      This expectation is because you've called AshOban.config\3 with `pro?: true`.
+      This expectation is because you're using almost one Oban.Pro's plugin`.
       """
     end
 
@@ -561,7 +564,7 @@ defmodule AshOban do
       |> AshOban.Info.oban_triggers_and_scheduled_actions()
       |> tap(fn triggers ->
         if opts[:require?] do
-          Enum.each(triggers, &require_queues!(base, resource, opts[:pro?], &1))
+          Enum.each(triggers, &require_queues!(base, resource, pro_dynamic_queues_plugin?, &1))
         end
       end)
       |> Enum.filter(fn

--- a/test/ash_oban_test.exs
+++ b/test/ash_oban_test.exs
@@ -80,4 +80,46 @@ defmodule AshObanTest do
              ]
            ] = config
   end
+
+  test "oban pro configuration" do
+    config =
+      AshOban.config([Api], [
+        engine: Oban.Pro.Engines.Smart,
+        plugins: [
+          {Oban.Pro.Plugins.DynamicCron, [
+            timezone: "Europe/Rome",
+            sync_mode: :automatic,
+            crontab: []
+          ]},
+          {Oban.Pro.Plugins.DynamicQueues,
+            queues: [
+              triggered_process: 10,
+              triggered_process_2: 10,
+              triggered_say_hello: 10
+            ]}
+        ],
+        queues: false
+      ], pro?: true)
+
+    assert [
+              engine: Oban.Pro.Engines.Smart,
+              plugins: [
+                {Oban.Pro.Plugins.DynamicCron, [
+                  timezone: "Europe/Rome",
+                  sync_mode: :automatic,
+                  crontab: [
+                    {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello, []},
+                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process, []}
+                  ]
+                ]},
+                {Oban.Pro.Plugins.DynamicQueues,
+                queues: [
+                  triggered_process: 10,
+                  triggered_process_2: 10,
+                  triggered_say_hello: 10
+                ]}
+              ],
+              queues: false
+            ] = config
+    end
 end

--- a/test/ash_oban_test.exs
+++ b/test/ash_oban_test.exs
@@ -83,43 +83,47 @@ defmodule AshObanTest do
 
   test "oban pro configuration" do
     config =
-      AshOban.config([Api], [
+      AshOban.config([Api],
         engine: Oban.Pro.Engines.Smart,
         plugins: [
-          {Oban.Pro.Plugins.DynamicCron, [
-            timezone: "Europe/Rome",
-            sync_mode: :automatic,
-            crontab: []
-          ]},
+          {Oban.Pro.Plugins.DynamicCron,
+           [
+             timezone: "Europe/Rome",
+             sync_mode: :automatic,
+             crontab: []
+           ]},
           {Oban.Pro.Plugins.DynamicQueues,
-            queues: [
-              triggered_process: 10,
-              triggered_process_2: 10,
-              triggered_say_hello: 10
-            ]}
+           queues: [
+             triggered_process: 10,
+             triggered_process_2: 10,
+             triggered_say_hello: 10
+           ]}
         ],
         queues: false
-      ])
+      )
 
     assert [
-              engine: Oban.Pro.Engines.Smart,
-              plugins: [
-                {Oban.Pro.Plugins.DynamicCron, [
+             engine: Oban.Pro.Engines.Smart,
+             plugins: [
+               {Oban.Pro.Plugins.DynamicCron,
+                [
                   timezone: "Europe/Rome",
                   sync_mode: :automatic,
                   crontab: [
-                    {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello, [paused: false]},
-                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process, [paused: false]}
+                    {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello,
+                     [paused: false]},
+                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process,
+                     [paused: false]}
                   ]
                 ]},
-                {Oban.Pro.Plugins.DynamicQueues,
+               {Oban.Pro.Plugins.DynamicQueues,
                 queues: [
                   triggered_process: 10,
                   triggered_process_2: 10,
                   triggered_say_hello: 10
                 ]}
-              ],
-              queues: false
-            ] = config
-    end
+             ],
+             queues: false
+           ] = config
+  end
 end

--- a/test/ash_oban_test.exs
+++ b/test/ash_oban_test.exs
@@ -99,7 +99,7 @@ defmodule AshObanTest do
             ]}
         ],
         queues: false
-      ], pro?: true)
+      ])
 
     assert [
               engine: Oban.Pro.Engines.Smart,

--- a/test/ash_oban_test.exs
+++ b/test/ash_oban_test.exs
@@ -108,8 +108,8 @@ defmodule AshObanTest do
                   timezone: "Europe/Rome",
                   sync_mode: :automatic,
                   crontab: [
-                    {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello, []},
-                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process, []}
+                    {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello, [paused: false]},
+                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process, [paused: false]}
                   ]
                 ]},
                 {Oban.Pro.Plugins.DynamicQueues,


### PR DESCRIPTION
With ObanPro and the DynamicQueues plugin, when a queue is paused with "paused: true", it's not enough to simply remove "paused: true" from the configuration to restart it, but it's necessary to specify "paused: false".

(maybe this should merged after [this one](https://github.com/ash-project/ash_oban/pull/21))

### Contributor checklist

- [X] Features include unit/acceptance tests
