### PR TITLE
chore: Move `simple_sat` to be used in dev/test environments only

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -123,7 +123,7 @@ defmodule AshOban.MixProject do
         {:oban, "~> 2.15"},
         {:postgrex, "~> 0.18"},
         # dev/test dependencies
-        {:simple_sat, "~> 0.1"},
+        {:simple_sat, "~> 0.1", only: [:dev, :test]},
         {:ex_doc, "~> 0.22", only: [:dev, :test], runtime: false},
         {:ex_check, "~> 0.12", only: [:dev, :test]},
         {:credo, ">= 0.0.0", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
As discussed on Discord - this shouldn't be an external dependency. 

It's even listed in the Mixfile as dev/test dependency, and now it actually is!

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
