### PR TITLE
Ensure `run_oban_trigger` and scheduler are aware of the tenant in context-driven multi tenancy

### DIFF
--- a/lib/changes/run_oban_trigger.ex
+++ b/lib/changes/run_oban_trigger.ex
@@ -16,7 +16,12 @@ defmodule AshOban.Changes.RunObanTrigger do
       AshOban.run_trigger(
         result,
         trigger,
-        Keyword.put(opts[:oban_job_opts] || [], :actor, context.actor)
+        Keyword.merge(
+          opts[:oban_job_opts] || [],
+          context
+          |> Ash.Context.to_opts()
+          |> Keyword.take([:actor, :tenant])
+        )
       )
 
       {:ok, result}

--- a/lib/transformers/define_schedulers.ex
+++ b/lib/transformers/define_schedulers.ex
@@ -246,7 +246,7 @@ defmodule AshOban.Transformers.DefineSchedulers do
                 {:ok, actor} ->
                   unquote(resource)
                   |> stream(actor, tenant)
-                  |> Stream.map(&AshOban.build_trigger(&1, trigger, actor: actor))
+                  |> Stream.map(&AshOban.build_trigger(&1, trigger, actor: actor, tenant: tenant))
                   |> insert()
 
                 {:error, e} ->


### PR DESCRIPTION
No tests added. I didn't find any for context-driven multi tenancy and not sure what would be the best approach here. Probably defining pair of resources where one provides the tenant and another one uses context multi tenancy ¯\_(ツ)_/¯ 

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
