### PR TITLE
fix: add missing tenant in handle_error query

### DIFF
--- a/lib/transformers/define_schedulers.ex
+++ b/lib/transformers/define_schedulers.ex
@@ -664,6 +664,7 @@ defmodule AshOban.Transformers.DefineSchedulers do
                 query()
                 |> Ash.Query.do_filter(primary_key)
                 |> Ash.Query.set_context(%{private: %{ash_oban?: true}})
+                |> Ash.Query.set_tenant(tenant)
                 |> Ash.Query.for_read(unquote(read_action), %{},
                   authorize?: authorize?,
                   actor: actor,


### PR DESCRIPTION
This sets the tenant on the `handle_error` query.

 It fixes an error when using `list_tenants` and `on_error` with attribute multitenancy without `global? true`.