### PR TITLE
[Bug fix] Don't assume plugins is not nulll

### DIFF
--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -698,7 +698,7 @@ defmodule AshOban do
 
     base =
       Keyword.update(base, :plugins, [], fn plugins ->
-        Enum.map(plugins, fn item ->
+        Enum.map(plugins || [], fn item ->
           if is_atom(item) do
             {item, []}
           else


### PR DESCRIPTION
We're using `Keyword.update` but according to the docs:
If the key does not exist, it inserts the given default value. **Does not pass the default value through the update function**.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
