### PR TITLE
feat: Implement :fail_oban_job? option for triggers

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,8 @@ if Mix.env() == :test do
       triggered_process_2: 10,
       triggered_say_hello: 10,
       triggered_tenant_aware: 10,
-      triggered_process_generic: 10
+      triggered_process_generic: 10,
+      triggered_fail_oban_job: 10
     ]
 
   config :ash_oban, actor_persister: AshOban.Test.ActorPersister

--- a/documentation/dsls/DSL-AshOban.md
+++ b/documentation/dsls/DSL-AshOban.md
@@ -140,6 +140,7 @@ end
 | [`where`](#oban-triggers-trigger-where){: #oban-triggers-trigger-where } | `any` |  | The filter expression to determine if something should be triggered |
 | [`sort`](#oban-triggers-trigger-sort){: #oban-triggers-trigger-sort } | `any` |  | The sort applied to the query that determines if something should be triggered |
 | [`on_error`](#oban-triggers-trigger-on_error){: #oban-triggers-trigger-on_error } | `atom` |  | An update action to call after the last attempt has failed. See the getting started guide for more. |
+| [`on_error_fails_oban_job?`](#oban-triggers-trigger-on_error_fails_oban_job?){: #oban-triggers-trigger-on_error_fails_oban_job?} | `boolean` |  | Fail the Oban Job if the action fails. |
 | [`worker_opts`](#oban-triggers-trigger-worker_opts){: #oban-triggers-trigger-worker_opts } | `keyword` | `[]` | Options to set on the worker. ATTENTION: this may overwrite options set by ash_oban, make sure you know what you are doing. See [Oban.Worker](https://hexdocs.pm/oban/Oban.Worker.html#module-defining-workers) for options and [Oban.Pro.Worker](https://oban.pro/docs/pro/Oban.Pro.Worker.html) for oban pro |
 
 

--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -35,7 +35,8 @@ defmodule AshOban do
             worker: module,
             worker_opts: keyword(),
             __identifier__: atom,
-            on_error: atom
+            on_error: atom,
+            on_error_fails_oban_job?: boolean()
           }
 
     defstruct [
@@ -69,6 +70,7 @@ defmodule AshOban do
       :worker,
       :worker_opts,
       :on_error,
+      :on_error_fails_oban_job?,
       :log_final_error?,
       :log_errors?,
       :__identifier__
@@ -271,6 +273,13 @@ defmodule AshOban do
         type: :atom,
         doc:
           "An update action to call after the last attempt has failed. See the getting started guide for more."
+      ],
+      on_error_fails_oban_job?: [
+        type: :boolean,
+        default: false,
+        doc: """
+        Determines if the oban job will be failed on the last attempt when there is an on_error handler that is called. If there is no on_error, then the action is always marked as failed on the last attempt.
+        """
       ],
       worker_opts: [
         type: :keyword_list,

--- a/lib/transformers/define_schedulers.ex
+++ b/lib/transformers/define_schedulers.ex
@@ -717,16 +717,22 @@ defmodule AshOban.Transformers.DefineSchedulers do
                         |> AshOban.update_or_destroy()
                         |> case do
                           :ok ->
-                            :ok
+                            case unquote(trigger.on_error_fails_oban_job?) do
+                              true -> reraise error, stacktrace
+                              false -> :ok
+                            end
 
-                          {:ok, result} ->
-                            :ok
+                          {:ok, _} ->
+                            case unquote(trigger.on_error_fails_oban_job?) do
+                              true -> reraise error, stacktrace
+                              false -> :ok
+                            end
 
                           {:error, error} ->
                             error = Ash.Error.to_ash_error(error, stacktrace)
 
                             Logger.error("""
-                            Error handler failed for #{inspect(unquote(resource))}: #{inspect(primary_key)}!
+                            Error handler failed for #{inspect(unquote(resource))}: #{inspect(primary_key)}!!
 
                             #{inspect(Exception.format(:error, error, AshOban.stacktrace(error)))}
                             """)


### PR DESCRIPTION
By default AshOban doesn't fail the Oban job, this new option gives users the control wether they want to fail the job or not.

### Contributor checklist

- [x] Features include unit/acceptance tests
