### PR TITLE
scheduled_actions: support passing action_arguments to AshOban.schedule/3

### DIFF
--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -560,7 +560,9 @@ defmodule AshOban do
 
   ## Options
 
-    `:actor` - the actor to set on the job. Requires configuring an actor persister.
+  - `:actor` - the actor to set on the job. Requires configuring an actor persister.
+  - `:action_arguments` - additional arguments to merge into the action invocation's arguments map.
+     affects the uniqueness checks for the job. This only affects scheduled actions.
   """
   def schedule(resource, trigger, opts \\ []) do
     case trigger do
@@ -576,7 +578,9 @@ defmodule AshOban do
     end
     |> case do
       %AshOban.Schedule{worker: worker} = schedule ->
-        %{}
+        %{
+          action_arguments: opts[:action_arguments] || %{}
+        }
         |> store_actor(opts[:actor], schedule.actor_persister)
         |> worker.new()
         |> Oban.insert!()

--- a/lib/transformers/define_action_workers.ex
+++ b/lib/transformers/define_action_workers.ex
@@ -83,7 +83,9 @@ defmodule AshOban.Transformers.DefineActionWorkers do
                 unquote(scheduled_action.debug?)
               )
 
-              input = unquote(Macro.escape(scheduled_action.action_input || %{}))
+              input =
+                (args["action_arguments"] || %{})
+                |> Map.merge(unquote(Macro.escape(scheduled_action.action_input || %{})))
 
               input =
                 if job.max_attempts == job.attempt do

--- a/test/ash_oban_test.exs
+++ b/test/ash_oban_test.exs
@@ -159,7 +159,7 @@ defmodule AshObanTest do
   end
 
   test "on_error_fails_job? true with custom backoff will fail the job" do
-    model =
+    _model =
       Triggered
       |> Ash.Changeset.for_create(:create, %{})
       |> Ash.create!()

--- a/test/support/triggered.ex
+++ b/test/support/triggered.ex
@@ -173,8 +173,16 @@ defmodule AshOban.Test.Triggered do
     end
 
     action :say_hello, :string do
+      argument :target, :string
+
       run fn input, _ ->
-        {:ok, "Hello"}
+        case input.arguments do
+          %{target: target} ->
+            {:ok, "Hello, #{target}"}
+
+          _ ->
+            {:ok, "Hello"}
+        end
       end
     end
   end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

I didn't think any tests were useful here. The scheduled action always returns :ok so it's impossible to tell that the arguments were being properly without some other modifications.

I also was debating splitting the schedule/3 function into two (splitting the scheduled actions and triggers functions) since it doesn't really make sense to provide the action_arguments option to the trigger scheduler, but ended up just making a note of that in the documentation.