### PR TITLE
docs: update cron expression in schedule example

### DIFF
--- a/documentation/topics/triggers-and-scheduled-actions.md
+++ b/documentation/topics/triggers-and-scheduled-actions.md
@@ -113,7 +113,7 @@ end
 Then you could schedule it to run every 6 hours:
 
 ```elixir
-schedule :import_from_github, "@hourly" do
+schedule :import_from_github, "0 */6 * * *" do
   worker_module_name AshOban.Test.Triggered.AshOban.ActionWorker.SayHello
 end
 ```


### PR DESCRIPTION
In the prose it says _every 6 hours_, but the cron expression specified hourly. This updates the expression to match the surrounding text.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
