### PR TITLE
when oban.pro is false, defaults crontab options to []

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -20,13 +20,23 @@ if Mix.env() == :test do
       {Oban.Plugins.Cron, []}
     ],
     queues: [
-      triggered_process_with_state: 10,
       triggered_process: 10,
       triggered_process_2: 10,
       triggered_say_hello: 10,
       triggered_tenant_aware: 10,
       triggered_process_generic: 10,
       triggered_fail_oban_job: 10
+    ]
+
+  config :ash_oban, :oban_pro,
+    testing: :manual,
+    repo: AshOban.Test.Repo,
+    prefix: "private",
+    plugins: [
+      {Oban.Plugins.Cron, []}
+    ],
+    queues: [
+      triggered_pro_process_with_state: 10
     ]
 
   config :ash_oban, actor_persister: AshOban.Test.ActorPersister

--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -926,11 +926,7 @@ defmodule AshOban do
     state = Map.get(trigger, :state, nil)
 
     if not is_nil(state) && state in [:paused, :deleted] do
-      Logger.warning(
-        "The `state` option on triggers and scheduled actions is only supported when using Oban Pro. Ignoring state #{inspect(state)}"
-      )
-
-      :ok
+      raise "The `state` option on triggers and scheduled actions is only supported when using Oban Pro. Ignoring state #{inspect(state)}"
     end
 
     []

--- a/test/ash_oban_test.exs
+++ b/test/ash_oban_test.exs
@@ -1,10 +1,11 @@
 defmodule AshObanTest do
   use ExUnit.Case, async: false
-  import ExUnit.CaptureLog
   doctest AshOban
 
   alias AshOban.Test.Domain
+  alias AshOban.Test.DomainPro
   alias AshOban.Test.Triggered
+  # alias AshOban.Test.TriggeredPro
 
   use Oban.Testing, repo: AshOban.Test.Repo, prefix: "private"
 
@@ -13,374 +14,243 @@ defmodule AshObanTest do
   setup_all do
     AshOban.Test.Repo.start_link()
     Oban.start_link(AshOban.config([Domain], Application.get_env(:ash_oban, :oban)))
-
     :ok
   end
 
-  setup do
-    Enum.each(
-      [
-        :triggered_process_with_state,
-        :triggered_process,
-        :triggered_process_2,
-        :triggered_say_hello,
-        :triggered_tenant_aware,
-        :triggered_process_generic,
-        :triggered_fail_oban_job
-      ],
-      &Oban.drain_queue(queue: &1)
-    )
-  end
-
-  test "nothing happens if no records exist" do
-    assert %{success: 7} = AshOban.Test.schedule_and_run_triggers(Triggered)
-  end
-
-  test "if a record exists, it is processed" do
-    Triggered
-    |> Ash.Changeset.for_create(:create, %{})
-    |> Ash.create!()
-
-    assert %{success: 2} =
-             AshOban.Test.schedule_and_run_triggers({Triggered, :process},
-               actor: %AshOban.Test.ActorPersister.FakeActor{id: 1}
-             )
-  end
-
-  test "extra args are set on a job" do
-    Triggered
-    |> Ash.Changeset.for_create(:create, %{})
-    |> Ash.create!()
-
-    AshOban.schedule(Triggered, :process)
-
-    assert [_scheduler] =
-             all_enqueued(worker: Triggered.AshOban.Scheduler.Process)
-
-    # run scheduler
-    Oban.drain_queue(queue: :triggered_process)
-
-    assert [job] =
-             all_enqueued(worker: Triggered.AshOban.Worker.Process)
-
-    assert job.args["extra_arg"] == 1
-  end
-
-  test "sort is applied when scheduling" do
-    triggered1 =
-      Triggered
-      |> Ash.Changeset.for_create(:create, %{})
-      |> Ash.create!()
-
-    triggered2 =
-      Triggered
-      |> Ash.Changeset.for_create(:create, %{})
-      |> Ash.create!()
-
-    assert %{success: 3} =
-             AshOban.Test.schedule_and_run_triggers({Triggered, :process},
-               actor: %AshOban.Test.ActorPersister.FakeActor{id: 1}
-             )
-
-    triggered1 =
-      Ash.reload!(triggered1)
-
-    triggered2 =
-      Ash.reload!(triggered2)
-
-    assert DateTime.before?(triggered1.updated_at, triggered2.updated_at)
-  end
-
-  test "a record can be processed manually with additional arguments" do
-    record =
-      Triggered
-      |> Ash.Changeset.for_create(:create, %{})
-      |> Ash.create!()
-
-    AshOban.run_trigger(record, :process,
-      action_arguments: %{special_arg: "special_value"},
-      actor: %AshOban.Test.ActorPersister.FakeActor{id: 1}
-    )
-
-    AshOban.Test.schedule_and_run_triggers(Triggered)
-
-    assert_receive {:special_arg, "special_value"}
-  end
-
-  test "actions done atomically will be done atomically" do
-    Triggered
-    |> Ash.Changeset.for_create(:create, %{})
-    |> Ash.create!()
-
-    assert %{success: 2} =
-             AshOban.Test.schedule_and_run_triggers({Triggered, :process_atomically})
-
-    assert Ash.read_first!(Triggered).processed
-  end
-
-  test "only jobs for the specified tenant are queued" do
-    tenant_1 =
-      Triggered
-      |> Ash.Changeset.for_create(:create, %{})
-      |> Ash.create!()
-
-    tenant_2 =
-      Triggered
-      |> Ash.Changeset.for_create(:create, %{tenant_id: 2})
-      |> Ash.create!()
-
-    assert %{success: 2} =
-             AshOban.Test.schedule_and_run_triggers({Triggered, :tenant_aware})
-
-    refute Ash.load!(tenant_1, :processed).processed
-    assert Ash.load!(tenant_2, :processed).processed
-  end
-
-  test "on_error_fails_job? false will succeed the job" do
-    model =
-      Triggered
-      |> Ash.Changeset.for_create(:create, %{})
-      |> Ash.create!()
-
-    assert %{success: 2, discard: 0} =
-             AshOban.Test.schedule_and_run_triggers({Triggered, :dont_fail_oban_job})
-
-    assert Ash.load!(model, :processed).processed
-  end
-
-  test "on_error_fails_job? true will fail the job" do
-    model =
-      Triggered
-      |> Ash.Changeset.for_create(:create, %{})
-      |> Ash.create!()
-
-    assert %{discard: 1, success: 1} =
-             AshOban.Test.schedule_and_run_triggers({Triggered, :fail_oban_job})
-
-    assert Ash.load!(model, :processed).processed
-  end
-
-  test "on_error_fails_job? true with custom backoff will fail the job" do
-    _model =
-      Triggered
-      |> Ash.Changeset.for_create(:create, %{})
-      |> Ash.create!()
-
-    # Im not sure how to properly test that backoff has been called
-    assert %{failure: 1, success: 1} =
-             AshOban.Test.schedule_and_run_triggers({Triggered, :fail_oban_job_custom_backoff})
-  end
-
-  @tag :focus
-  test "bulk create triggers after_batch change" do
-    [
-      %{number: 1},
-      %{number: 2},
-      %{number: 3},
-      %{number: 4}
-    ]
-    |> Ash.bulk_create!(Triggered, :bulk_create)
-
-    jobs =
-      all_enqueued(worker: Triggered.AshOban.Worker.ProcessAtomically) |> Enum.sort_by(& &1.id)
-
-    assert [1, 2, 3, 4] = Enum.map(jobs, &Map.get(&1.args, "number"))
-  end
-
-  test "if an actor is not set, it is nil when executing the job" do
-    Triggered
-    |> Ash.Changeset.for_create(:create)
-    |> Ash.create!()
-
-    assert %{success: 9, failure: 1} =
-             AshOban.Test.schedule_and_run_triggers(Triggered)
-  end
-
-  test "if a tenant is converted with Ash.ToTenant" do
-    tenant =
-      Triggered
-      |> Ash.Changeset.for_create(:create, %{tenant_id: 2})
-      |> Ash.create!()
-
-    tenant =
-      Triggered
-      |> Ash.Query.for_read(:read)
-      |> Ash.read_one!(tenant: tenant)
-
-    tenant
-    |> Ash.Changeset.for_update(:update_triggered)
-    |> Ash.update!()
-
-    assert %{success: 10, failure: 0} =
-             AshOban.Test.schedule_and_run_triggers(Triggered)
-  end
-
-  test "dsl introspection" do
-    assert [
-             %AshOban.Trigger{action: :process_with_state},
-             %AshOban.Trigger{action: :process},
-             %AshOban.Trigger{action: :process_atomically},
-             %AshOban.Trigger{action: :process, scheduler: nil},
-             %AshOban.Trigger{name: :process_generic},
-             %AshOban.Trigger{name: :tenant_aware},
-             %AshOban.Trigger{name: :fail_oban_job},
-             %AshOban.Trigger{name: :dont_fail_oban_job},
-             %AshOban.Trigger{name: :fail_oban_job_custom_backoff}
-           ] = AshOban.Info.oban_triggers(Triggered)
-  end
-
-  test "cron configuration" do
-    config =
-      AshOban.config([Domain],
-        plugins: [
-          {Oban.Plugins.Cron, []}
-        ],
-        queues: [
-          triggered_process_with_state: 10,
-          triggered_process: 10,
-          triggered_process_2: 10,
-          triggered_say_hello: 10,
-          triggered_tenant_aware: 10,
-          triggered_process_generic: 10,
-          triggered_fail_oban_job: 10
-        ]
-      )
-
-    assert [
-             plugins: [
-               {Oban.Plugins.Cron,
-                [
-                  crontab: [
-                    {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello, []},
-                    {"* * * * *",
-                     AshOban.Test.Triggered.AshOban.Scheduler.FailObanJobWithCustomBackoff, []},
-                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.DontFailObanJob, []},
-                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.FailObanJob, []},
-                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.TenantAware, []},
-                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.ProcessGeneric, []},
-                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.ProcessAtomically, []},
-                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process, []},
-                    {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.ProcessWithState, []}
-                  ]
-                ]}
-             ],
-             queues: [
-               triggered_process_with_state: 10,
-               triggered_process: 10,
-               triggered_process_2: 10,
-               triggered_say_hello: 10,
-               triggered_tenant_aware: 10,
-               triggered_process_generic: 10,
-               triggered_fail_oban_job: 10
-             ]
-           ] = config
-  end
-
-  describe "oban pro configuration" do
+  describe "oban free tier" do
     setup [:ash_oban_pro]
-    @tag pro?: true
-    test "if oban.pro true, puts `state` in crontab opts" do
-      config =
-        AshOban.config([Domain],
-          engine: Oban.Pro.Engines.Smart,
-          plugins: [
-            {Oban.Pro.Plugins.DynamicCron,
-             [
-               timezone: "Europe/Rome",
-               sync_mode: :automatic,
-               crontab: []
-             ]},
-            {Oban.Pro.Plugins.DynamicQueues,
-             queues: [
-               triggered_process_with_state: 10,
-               triggered_process: 10,
-               triggered_process_2: 10,
-               triggered_say_hello: 10,
-               triggered_tenant_aware: 10,
-               triggered_process_generic: 10,
-               triggered_fail_oban_job: 10
-             ]}
-          ],
-          queues: false
-        )
+    @describetag pro?: false
 
-      assert [
-               engine: Oban.Pro.Engines.Smart,
-               plugins: [
-                 {Oban.Pro.Plugins.DynamicCron,
-                  [
-                    timezone: "Europe/Rome",
-                    sync_mode: :automatic,
-                    crontab: [
-                      {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello,
-                       [paused: false]},
-                      {"* * * * *",
-                       AshOban.Test.Triggered.AshOban.Scheduler.FailObanJobWithCustomBackoff,
-                       [paused: false]},
-                      {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.DontFailObanJob,
-                       [paused: false]},
-                      {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.FailObanJob,
-                       [paused: false]},
-                      {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.TenantAware,
-                       [paused: false]},
-                      {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.ProcessGeneric,
-                       [paused: false]},
-                      {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.ProcessAtomically,
-                       [paused: false]},
-                      {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process,
-                       [paused: false]},
-                      {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.ProcessWithState,
-                       [paused: true]}
-                    ]
-                  ]},
-                 {Oban.Pro.Plugins.DynamicQueues,
-                  queues: [
-                    triggered_process_with_state: 10,
-                    triggered_process: 10,
-                    triggered_process_2: 10,
-                    triggered_say_hello: 10,
-                    triggered_tenant_aware: 10,
-                    triggered_process_generic: 10,
-                    triggered_fail_oban_job: 10
-                  ]}
-               ],
-               queues: false
-             ] = config
+    setup do
+      Enum.each(
+        [
+          :triggered_process,
+          :triggered_process_2,
+          :triggered_say_hello,
+          :triggered_tenant_aware,
+          :triggered_process_generic,
+          :triggered_fail_oban_job
+        ],
+        &Oban.drain_queue(queue: &1)
+      )
     end
 
-    @tag pro?: false
-    test "if oban.pro is false, configuration removes `state` in crontab opts" do
+    test "nothing happens if no records exist" do
+      assert %{success: 7} = AshOban.Test.schedule_and_run_triggers(Triggered)
+    end
+
+    test "if a record exists, it is processed" do
+      Triggered
+      |> Ash.Changeset.for_create(:create, %{})
+      |> Ash.create!()
+
+      assert %{success: 2} =
+               AshOban.Test.schedule_and_run_triggers({Triggered, :process},
+                 actor: %AshOban.Test.ActorPersister.FakeActor{id: 1}
+               )
+    end
+
+    test "extra args are set on a job" do
+      Triggered
+      |> Ash.Changeset.for_create(:create, %{})
+      |> Ash.create!()
+
+      AshOban.schedule(Triggered, :process)
+
+      assert [_scheduler] =
+               all_enqueued(worker: Triggered.AshOban.Scheduler.Process)
+
+      # run scheduler
+      Oban.drain_queue(queue: :triggered_process)
+
+      assert [job] =
+               all_enqueued(worker: Triggered.AshOban.Worker.Process)
+
+      assert job.args["extra_arg"] == 1
+    end
+
+    test "sort is applied when scheduling" do
+      triggered1 =
+        Triggered
+        |> Ash.Changeset.for_create(:create, %{})
+        |> Ash.create!()
+
+      triggered2 =
+        Triggered
+        |> Ash.Changeset.for_create(:create, %{})
+        |> Ash.create!()
+
+      assert %{success: 3} =
+               AshOban.Test.schedule_and_run_triggers({Triggered, :process},
+                 actor: %AshOban.Test.ActorPersister.FakeActor{id: 1}
+               )
+
+      triggered1 =
+        Ash.reload!(triggered1)
+
+      triggered2 =
+        Ash.reload!(triggered2)
+
+      assert DateTime.before?(triggered1.updated_at, triggered2.updated_at)
+    end
+
+    test "a record can be processed manually with additional arguments" do
+      record =
+        Triggered
+        |> Ash.Changeset.for_create(:create, %{})
+        |> Ash.create!()
+
+      AshOban.run_trigger(record, :process,
+        action_arguments: %{special_arg: "special_value"},
+        actor: %AshOban.Test.ActorPersister.FakeActor{id: 1}
+      )
+
+      AshOban.Test.schedule_and_run_triggers(Triggered)
+
+      assert_receive {:special_arg, "special_value"}
+    end
+
+    test "actions done atomically will be done atomically" do
+      Triggered
+      |> Ash.Changeset.for_create(:create, %{})
+      |> Ash.create!()
+
+      assert %{success: 2} =
+               AshOban.Test.schedule_and_run_triggers({Triggered, :process_atomically})
+
+      assert Ash.read_first!(Triggered).processed
+    end
+
+    test "only jobs for the specified tenant are queued" do
+      tenant_1 =
+        Triggered
+        |> Ash.Changeset.for_create(:create, %{})
+        |> Ash.create!()
+
+      tenant_2 =
+        Triggered
+        |> Ash.Changeset.for_create(:create, %{tenant_id: 2})
+        |> Ash.create!()
+
+      assert %{success: 2} =
+               AshOban.Test.schedule_and_run_triggers({Triggered, :tenant_aware})
+
+      refute Ash.load!(tenant_1, :processed).processed
+      assert Ash.load!(tenant_2, :processed).processed
+    end
+
+    test "on_error_fails_job? false will succeed the job" do
+      model =
+        Triggered
+        |> Ash.Changeset.for_create(:create, %{})
+        |> Ash.create!()
+
+      assert %{success: 2, discard: 0} =
+               AshOban.Test.schedule_and_run_triggers({Triggered, :dont_fail_oban_job})
+
+      assert Ash.load!(model, :processed).processed
+    end
+
+    test "on_error_fails_job? true will fail the job" do
+      model =
+        Triggered
+        |> Ash.Changeset.for_create(:create, %{})
+        |> Ash.create!()
+
+      assert %{discard: 1, success: 1} =
+               AshOban.Test.schedule_and_run_triggers({Triggered, :fail_oban_job})
+
+      assert Ash.load!(model, :processed).processed
+    end
+
+    test "on_error_fails_job? true with custom backoff will fail the job" do
+      _model =
+        Triggered
+        |> Ash.Changeset.for_create(:create, %{})
+        |> Ash.create!()
+
+      # Im not sure how to properly test that backoff has been called
+      assert %{failure: 1, success: 1} =
+               AshOban.Test.schedule_and_run_triggers({Triggered, :fail_oban_job_custom_backoff})
+    end
+
+    @tag :focus
+    test "bulk create triggers after_batch change" do
+      [
+        %{number: 1},
+        %{number: 2},
+        %{number: 3},
+        %{number: 4}
+      ]
+      |> Ash.bulk_create!(Triggered, :bulk_create)
+
+      jobs =
+        all_enqueued(worker: Triggered.AshOban.Worker.ProcessAtomically) |> Enum.sort_by(& &1.id)
+
+      assert [1, 2, 3, 4] = Enum.map(jobs, &Map.get(&1.args, "number"))
+    end
+
+    test "if an actor is not set, it is nil when executing the job" do
+      Triggered
+      |> Ash.Changeset.for_create(:create)
+      |> Ash.create!()
+
+      assert %{success: 9, failure: 1} =
+               AshOban.Test.schedule_and_run_triggers(Triggered)
+    end
+
+    test "if a tenant is converted with Ash.ToTenant" do
+      tenant =
+        Triggered
+        |> Ash.Changeset.for_create(:create, %{tenant_id: 2})
+        |> Ash.create!()
+
+      tenant =
+        Triggered
+        |> Ash.Query.for_read(:read)
+        |> Ash.read_one!(tenant: tenant)
+
+      tenant
+      |> Ash.Changeset.for_update(:update_triggered)
+      |> Ash.update!()
+
+      assert %{success: 10, failure: 0} =
+               AshOban.Test.schedule_and_run_triggers(Triggered)
+    end
+
+    test "dsl introspection" do
+      assert [
+               %AshOban.Trigger{action: :process},
+               %AshOban.Trigger{action: :process_atomically},
+               %AshOban.Trigger{action: :process, scheduler: nil},
+               %AshOban.Trigger{name: :process_generic},
+               %AshOban.Trigger{name: :tenant_aware},
+               %AshOban.Trigger{name: :fail_oban_job},
+               %AshOban.Trigger{name: :dont_fail_oban_job},
+               %AshOban.Trigger{name: :fail_oban_job_custom_backoff}
+             ] = AshOban.Info.oban_triggers(Triggered)
+    end
+
+    test "cron configuration" do
       config =
         AshOban.config([Domain],
-          engine: Oban.Pro.Engines.Smart,
           plugins: [
-            {Oban.Pro.Plugins.DynamicCron,
-             [
-               timezone: "Europe/Rome",
-               sync_mode: :automatic,
-               crontab: []
-             ]},
-            {Oban.Pro.Plugins.DynamicQueues,
-             queues: [
-               triggered_process_with_state: 10,
-               triggered_process: 10,
-               triggered_process_2: 10,
-               triggered_say_hello: 10,
-               triggered_tenant_aware: 10,
-               triggered_process_generic: 10,
-               triggered_fail_oban_job: 10
-             ]}
+            {Oban.Plugins.Cron, []}
           ],
-          queues: false
+          queues: [
+            triggered_process: 10,
+            triggered_process_2: 10,
+            triggered_say_hello: 10,
+            triggered_tenant_aware: 10,
+            triggered_process_generic: 10,
+            triggered_fail_oban_job: 10
+          ]
         )
 
       assert [
-               engine: Oban.Pro.Engines.Smart,
                plugins: [
-                 {Oban.Pro.Plugins.DynamicCron,
+                 {Oban.Plugins.Cron,
                   [
-                    timezone: "Europe/Rome",
-                    sync_mode: :automatic,
                     crontab: [
                       {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello, []},
                       {"* * * * *",
@@ -391,19 +261,71 @@ defmodule AshObanTest do
                       {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.ProcessGeneric, []},
                       {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.ProcessAtomically,
                        []},
-                      {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process, []},
-                      {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.ProcessWithState, []}
+                      {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.Process, []}
+                    ]
+                  ]}
+               ],
+               queues: [
+                 triggered_process: 10,
+                 triggered_process_2: 10,
+                 triggered_say_hello: 10,
+                 triggered_tenant_aware: 10,
+                 triggered_process_generic: 10,
+                 triggered_fail_oban_job: 10
+               ]
+             ] = config
+    end
+  end
+
+  describe "oban pro tier" do
+    setup [:ash_oban_pro]
+
+    setup do
+      Enum.each(
+        [
+          :triggered_pro_process_with_state
+        ],
+        &Oban.drain_queue(queue: &1)
+      )
+    end
+
+    @tag pro?: true
+    test "if oban.pro true, puts `state` in crontab opts" do
+      Oban.start_link(AshOban.config([DomainPro], Application.get_env(:ash_oban, :oban_pro)))
+
+      config =
+        AshOban.config([DomainPro],
+          engine: Oban.Pro.Engines.Smart,
+          plugins: [
+            {Oban.Pro.Plugins.DynamicCron,
+             [
+               timezone: "Europe/Rome",
+               sync_mode: :automatic,
+               crontab: []
+             ]},
+            {Oban.Pro.Plugins.DynamicQueues,
+             queues: [
+               triggered_pro_process_with_state: 10
+             ]}
+          ],
+          queues: false
+        )
+
+      assert [
+               engine: Oban.Pro.Engines.Smart,
+               plugins: [
+                 {Oban.Pro.Plugins.DynamicCron,
+                  [
+                    timezone: "Europe/Rome",
+                    sync_mode: :automatic,
+                    crontab: [
+                      {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.ProcessWithState,
+                       [paused: true]}
                     ]
                   ]},
                  {Oban.Pro.Plugins.DynamicQueues,
                   queues: [
-                    triggered_process_with_state: 10,
-                    triggered_process: 10,
-                    triggered_process_2: 10,
-                    triggered_say_hello: 10,
-                    triggered_tenant_aware: 10,
-                    triggered_process_generic: 10,
-                    triggered_fail_oban_job: 10
+                    triggered_pro_process_with_state: 10
                   ]}
                ],
                queues: false
@@ -411,10 +333,14 @@ defmodule AshObanTest do
     end
 
     @tag pro?: false
-    test "if oban.pro is false, setting state on Plugins captures log warning" do
-      log =
-        capture_log(fn ->
-          AshOban.config([Domain],
+    test "if oban.pro is false, setting state on Plugins raises error message" do
+      assert_raise(
+        RuntimeError,
+        "The `state` option on triggers and scheduled actions is only supported when using Oban Pro. Ignoring state :paused",
+        fn ->
+          Oban.start_link(AshOban.config([DomainPro], Application.get_env(:ash_oban, :oban_pro)))
+
+          AshOban.config([DomainPro],
             engine: Oban.Pro.Engines.Smart,
             plugins: [
               {Oban.Pro.Plugins.DynamicCron,
@@ -425,21 +351,13 @@ defmodule AshObanTest do
                ]},
               {Oban.Pro.Plugins.DynamicQueues,
                queues: [
-                 triggered_process_with_state: 10,
-                 triggered_process: 10,
-                 triggered_process_2: 10,
-                 triggered_say_hello: 10,
-                 triggered_tenant_aware: 10,
-                 triggered_process_generic: 10,
-                 triggered_fail_oban_job: 10
+                 triggered_pro_process_with_state: 10
                ]}
             ],
             queues: false
           )
-        end)
-
-      assert log =~
-               "The `state` option on triggers and scheduled actions is only supported when using Oban Pro. Ignoring state :paused"
+        end
+      )
     end
   end
 
@@ -449,5 +367,8 @@ defmodule AshObanTest do
     :ok
   end
 
-  defp ash_oban_pro(context), do: context
+  defp ash_oban_pro(_context) do
+    Application.put_env(:ash_oban, :pro?, false)
+    :ok
+  end
 end

--- a/test/support/domain_pro.ex
+++ b/test/support/domain_pro.ex
@@ -1,0 +1,11 @@
+defmodule AshOban.Test.DomainPro do
+  @moduledoc """
+  A domain to test oban triggers with pro features.
+  """
+  use Ash.Domain,
+    validate_config_inclusion?: false
+
+  resources do
+    resource AshOban.Test.TriggeredPro
+  end
+end

--- a/test/support/triggered.ex
+++ b/test/support/triggered.ex
@@ -14,23 +14,6 @@ defmodule AshOban.Test.Triggered do
 
   oban do
     triggers do
-      trigger :process_with_state do
-        state :paused
-        trigger_once? true
-        action :process_with_state
-        where expr(processed != true)
-        sort inserted_at: :asc
-        max_attempts 2
-
-        extra_args(fn _record ->
-          %{extra_arg: 1}
-        end)
-
-        worker_read_action :read
-        worker_module_name AshOban.Test.Triggered.AshOban.Worker.ProcessWithState
-        scheduler_module_name AshOban.Test.Triggered.AshOban.Scheduler.ProcessWithState
-      end
-
       trigger :process do
         trigger_once? true
         action :process
@@ -164,21 +147,6 @@ defmodule AshOban.Test.Triggered do
 
     update :process_atomically do
       change set_attribute(:processed, true)
-    end
-
-    update :process_with_state do
-      require_atomic? false
-      change set_attribute(:processed, true)
-      argument :special_arg, :string
-
-      change fn changeset, context ->
-        if changeset.arguments[:special_arg] do
-          send(self(), {:special_arg, changeset.arguments[:special_arg]})
-        end
-
-        send(self(), {:actor, context.actor})
-        changeset
-      end
     end
 
     update :process do

--- a/test/support/triggered_pro.ex
+++ b/test/support/triggered_pro.ex
@@ -1,0 +1,87 @@
+defmodule AshOban.Test.TriggeredPro do
+  @moduledoc """
+  A resource to test oban triggers with pro features.
+  """
+  use Ash.Resource,
+    domain: AshOban.Test.DomainPro,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshOban]
+
+  multitenancy do
+    strategy :attribute
+    attribute :tenant_id
+    global? true
+  end
+
+  oban do
+    triggers do
+      trigger :process_with_state do
+        state :paused
+        trigger_once? true
+        action :process_with_state
+        where expr(processed != true)
+        sort inserted_at: :asc
+        max_attempts 2
+
+        extra_args(fn _record ->
+          %{extra_arg: 1}
+        end)
+
+        worker_read_action :read
+        worker_module_name AshOban.Test.Triggered.AshOban.Worker.ProcessWithState
+        scheduler_module_name AshOban.Test.Triggered.AshOban.Scheduler.ProcessWithState
+      end
+    end
+  end
+
+  policies do
+    policy action(:process) do
+      authorize_if actor_present()
+    end
+
+    policy always() do
+      authorize_if always()
+    end
+  end
+
+  actions do
+    defaults create: [:tenant_id]
+
+    read :read do
+      primary? true
+      pagination keyset?: true
+    end
+
+    update :process_with_state do
+      require_atomic? false
+      change set_attribute(:processed, true)
+      argument :special_arg, :string
+
+      change fn changeset, context ->
+        if changeset.arguments[:special_arg] do
+          send(self(), {:special_arg, changeset.arguments[:special_arg]})
+        end
+
+        send(self(), {:actor, context.actor})
+        changeset
+      end
+    end
+  end
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :processed, :boolean, default: false, allow_nil?: false
+    attribute :number, :integer, public?: true
+    attribute :tenant_id, :integer, allow_nil?: false, default: 1
+    timestamps()
+  end
+
+  defimpl Ash.ToTenant do
+    def to_tenant(%{tenant_id: id}, _resource), do: id
+  end
+end


### PR DESCRIPTION
If Oban.Pro is set to `false` setting `state` on triggers results to the server not starting due to Oban's failures.

```
** (Mix) Could not start application app: ExampleApp.Application.start(:normal, []) returned an error: shutdown: failed to start child: Oban
    ** (EXIT) an exception was raised:
        ** (ArgumentError) invalid value for :plugins, invalid value for :crontab, expected valid job options, got: [paused: true]
            (oban 2.20.1) lib/oban/config.ex:99: Oban.Config.new/1
            (oban 2.20.1) lib/oban.ex:509: Oban.start_link/1
            (stdlib 6.2.2) supervisor.erl:959: :supervisor.do_start_child_i/3
            (stdlib 6.2.2) supervisor.erl:945: :supervisor.do_start_child/3
            (stdlib 6.2.2) supervisor.erl:929: anonymous fn/3 in :supervisor.start_children/2
            (stdlib 6.2.2) supervisor.erl:1820: :supervisor.children_map/4
            (stdlib 6.2.2) supervisor.erl:889: :supervisor.init_children/2
            (stdlib 6.2.2) gen_server.erl:2229: :gen_server.init_it/2
            (stdlib 6.2.2) gen_server.erl:2184: :gen_server.init_it/6
            (stdlib 6.2.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```
**Findings**

Setting `state` for crontab options is only applicable for `Oban.Pro`


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
