### PR TITLE
Disable peer leadership when plugins are disabled

### DIFF
--- a/test/ash_oban_test.exs
+++ b/test/ash_oban_test.exs
@@ -291,6 +291,16 @@ defmodule AshObanTest do
                ]
              ] = config
     end
+
+    test "disabling peer mode when plugins are disabled" do
+      config = AshOban.config([Domain], [plugins: []], require?: false)
+      assert config[:peer] == false
+      assert config[:plugins] == []
+
+      config = AshOban.config([Domain], [plugins: false], require?: false)
+      assert config[:peer] == false
+      assert config[:plugins] == []
+    end
   end
 
   describe "oban pro tier" do


### PR DESCRIPTION
The `Oban.Config` automatically disables peer leadership when `plugins: []` or `plugins: false` are set. The AshOban config would modify plugins before they reached `Oban.Config`, which left peer leadership enabled.

It was always possible to disable leadership by setting `peer: false`, but this change ensures the standard `plugins: false` behaviour matches standard Oban.

(There's a light bit of refactoring I sneaked in while I was working through the cause of the issue)

---

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
