### PR TITLE
Better formatting for error messages

### DIFF
--- a/lib/transformers/define_schedulers.ex
+++ b/lib/transformers/define_schedulers.ex
@@ -565,7 +565,7 @@ defmodule AshOban.Transformers.DefineSchedulers do
 
           Error occurred on action: #{unquote(trigger.action)}.
 
-          #{inspect(Exception.format(:error, error, AshOban.stacktrace(error)))}
+          #{Exception.format(:error, error, AshOban.stacktrace(error))}
           """)
         end
       else
@@ -583,7 +583,7 @@ defmodule AshOban.Transformers.DefineSchedulers do
 
           Error occurred on action: #{unquote(trigger.action)}.
 
-          #{inspect(Exception.format(:error, error, AshOban.stacktrace(error)))}
+          #{Exception.format(:error, error, AshOban.stacktrace(error))}
           """)
         end
       else
@@ -829,7 +829,7 @@ defmodule AshOban.Transformers.DefineSchedulers do
                             Logger.error("""
                             Error handler failed for #{inspect(unquote(resource))}: #{inspect(primary_key)}!!
 
-                            #{inspect(Exception.format(:error, error, AshOban.stacktrace(error)))}
+                            #{Exception.format(:error, error, AshOban.stacktrace(error))}
                             """)
 
                             reraise error, stacktrace


### PR DESCRIPTION
By wrapping the call to `Exception.format` with `inspect` newlines are literally printed as `\n` which produces ugly error messages. By removing the call to `inspect` we just let the exception formatting do its job :)


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
