### PR TITLE
feat: `default_actor` on triggers and scheduled actions

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-oban.md
+++ b/documentation/tutorials/getting-started-with-ash-oban.md
@@ -262,6 +262,40 @@ trigger :name do
 end
 ```
 
+### Using a default actor without a persister
+
+If your trigger or scheduled action should always run as a fixed system actor
+(for example, on a cron schedule that has no real user behind it), you can set
+a `default_actor` directly in the DSL. No actor persister is required.
+
+```elixir
+trigger :nightly_cleanup do
+  action :cleanup
+  default_actor %MyApp.SystemActor{id: "system"}
+end
+
+scheduled_actions do
+  schedule :daily_report, "0 0 * * *" do
+    action :generate_report
+    default_actor %MyApp.SystemActor{id: "system"}
+  end
+end
+```
+
+The `default_actor` is a literal value (a map or struct), evaluated at the
+resource's compile time. If you use a struct, make sure its module is compiled
+before the resource that references it. It is only used when no actor is
+supplied via job args. The precedence is:
+
+1. Actor supplied at schedule time (via `AshOban.schedule/3`, `AshOban.run_trigger/3`,
+   or a changeset context) and round-tripped through the configured `actor_persister`
+2. The `default_actor` configured on the trigger / scheduled action
+3. `nil`
+
+This is useful for system-actor flows where the actor is constant and there is
+nothing to serialize. If you need a fresh database record on each run, configure
+an `actor_persister` and use its `lookup(nil)` callback instead.
+
 
 ### Considerations
 

--- a/lib/ash_oban.ex
+++ b/lib/ash_oban.ex
@@ -43,6 +43,7 @@ defmodule AshOban do
             log_errors?: boolean(),
             debug?: boolean(),
             actor_persister: module() | :none | nil,
+            default_actor: any(),
             max_scheduler_attempts: pos_integer(),
             read_metadata: (Ash.Resource.record() -> map),
             stream_batch_size: pos_integer(),
@@ -85,6 +86,7 @@ defmodule AshOban do
       :scheduler_priority,
       :worker_priority,
       :actor_persister,
+      :default_actor,
       :max_attempts,
       :trigger_once?,
       :stream_batch_size,
@@ -219,6 +221,16 @@ defmodule AshOban do
         type: {:or, [{:literal, :none}, {:behaviour, AshOban.PersistActor}]},
         doc:
           "An `AshOban.PersistActor` to use to store the actor. Defaults to to the configured `config :ash_oban, :actor_persister`. Set to `:none` to override the configured default."
+      ],
+      default_actor: [
+        type: :any,
+        doc: """
+        A default actor (literal value) used when no actor is supplied via job args.
+
+        Useful for system-actor flows that don't need an `actor_persister`. Cron-fired schedulers run with this actor, and worker jobs fall back to it when nothing was stored.
+
+        Applied when no actor was supplied to `AshOban.schedule/3` or `AshOban.run_trigger/3`, or when the configured persister resolves the stored actor to `nil`.
+        """
       ],
       list_tenants: [
         type:
@@ -500,6 +512,7 @@ defmodule AshOban do
             queue: atom,
             debug?: boolean,
             actor_persister: module() | :none | nil,
+            default_actor: any(),
             state: :active | :paused | :deleted,
             priority: non_neg_integer(),
             shared_context?: boolean(),
@@ -514,6 +527,7 @@ defmodule AshOban do
       :debug,
       :priority,
       :actor_persister,
+      :default_actor,
       :worker_module_name,
       :action_input,
       :list_tenants,
@@ -568,6 +582,14 @@ defmodule AshOban do
         type: {:or, [{:literal, :none}, {:behaviour, AshOban.PersistActor}]},
         doc:
           "An `AshOban.PersistActor` to use to store the actor. Defaults to to the configured `config :ash_oban, :actor_persister`. Set to `:none` to override the configured default."
+      ],
+      default_actor: [
+        type: :any,
+        doc: """
+        A default actor (literal value) used when no actor is supplied via job args. Useful for system-actor flows that don't need an `actor_persister`.
+
+        Applied when no actor was supplied to `AshOban.schedule/3`, or when the configured persister resolves the stored actor to `nil`.
+        """
       ],
       worker_module_name: [
         type: :module,
@@ -894,17 +916,20 @@ defmodule AshOban do
     end
   end
 
-  @spec lookup_actor(actor_json :: any, actor_persister :: module() | :none | nil) :: any
-  def lookup_actor(actor_json, actor_persister \\ nil) do
-    case actor_persister || Application.get_env(:ash_oban, :actor_persister) do
-      :none ->
-        {:ok, nil}
+  @spec lookup_actor(
+          actor_json :: any,
+          actor_persister :: module() | :none | nil,
+          default_actor :: any
+        ) :: {:ok, any} | {:error, Ash.Error.t()}
+  def lookup_actor(actor_json, actor_persister \\ nil, default_actor \\ nil) do
+    persister = actor_persister || Application.get_env(:ash_oban, :actor_persister)
 
-      nil ->
-        {:ok, nil}
-
-      persister ->
-        persister.lookup(actor_json)
+    with persister when persister not in [nil, :none] <- persister,
+         {:ok, actor} when not is_nil(actor) <- persister.lookup(actor_json) do
+      {:ok, actor}
+    else
+      {:error, _} = error -> error
+      _ -> {:ok, default_actor}
     end
   end
 

--- a/lib/transformers/define_action_workers.ex
+++ b/lib/transformers/define_action_workers.ex
@@ -100,7 +100,11 @@ defmodule AshOban.Transformers.DefineActionWorkers do
             tenant =
               if Map.has_key?(args, "tenant"), do: args["tenant"], else: List.first(tenants)
 
-            case AshOban.lookup_actor(args["actor"], unquote(scheduled_action.actor_persister)) do
+            case AshOban.lookup_actor(
+                   args["actor"],
+                   unquote(scheduled_action.actor_persister),
+                   unquote(Macro.escape(scheduled_action.default_actor))
+                 ) do
               {:ok, actor} ->
                 authorize? = AshOban.authorize?()
 

--- a/lib/transformers/define_schedulers.ex
+++ b/lib/transformers/define_schedulers.ex
@@ -256,7 +256,11 @@ defmodule AshOban.Transformers.DefineSchedulers do
                 list_tenants
             end)
             |> Enum.each(fn tenant ->
-              case AshOban.lookup_actor(args["actor"], unquote(trigger.actor_persister)) do
+              case AshOban.lookup_actor(
+                args["actor"],
+                unquote(trigger.actor_persister),
+                unquote(Macro.escape(trigger.default_actor))
+              ) do
                 {:ok, actor} ->
                   unquote(resource)
                   |> stream(actor, tenant)
@@ -754,7 +758,11 @@ defmodule AshOban.Transformers.DefineSchedulers do
               unquote(trigger.debug?)
             )
 
-            case AshOban.lookup_actor(args["actor"], unquote(trigger.actor_persister)) do
+            case AshOban.lookup_actor(
+                args["actor"],
+                unquote(trigger.actor_persister),
+                unquote(Macro.escape(trigger.default_actor))
+              ) do
               {:ok, actor} ->
                 authorize? = AshOban.authorize?()
 
@@ -875,7 +883,11 @@ defmodule AshOban.Transformers.DefineSchedulers do
               ) do
             authorize? = AshOban.authorize?()
 
-            case AshOban.lookup_actor(args["actor"], unquote(trigger.actor_persister)) do
+            case AshOban.lookup_actor(
+                args["actor"],
+                unquote(trigger.actor_persister),
+                unquote(Macro.escape(trigger.default_actor))
+              ) do
               {:ok, actor} ->
                 tenant = args["tenant"]
 
@@ -1030,7 +1042,11 @@ defmodule AshOban.Transformers.DefineSchedulers do
       quote location: :keep, generated: true do
         @impl unquote(worker)
         def unquote(function_name)(%Oban.Job{args: %{"primary_key" => primary_key} = args} = job) do
-          case AshOban.lookup_actor(args["actor"], unquote(trigger.actor_persister)) do
+          case AshOban.lookup_actor(
+                args["actor"],
+                unquote(trigger.actor_persister),
+                unquote(Macro.escape(trigger.default_actor))
+              ) do
             {:ok, actor} ->
               authorize? = AshOban.authorize?()
 
@@ -1120,7 +1136,11 @@ defmodule AshOban.Transformers.DefineSchedulers do
               unquote(trigger.debug?)
             )
 
-            case AshOban.lookup_actor(args["actor"], unquote(trigger.actor_persister)) do
+            case AshOban.lookup_actor(
+                args["actor"],
+                unquote(trigger.actor_persister),
+                unquote(Macro.escape(trigger.default_actor))
+              ) do
               {:ok, actor} ->
                 authorize? = AshOban.authorize?()
 
@@ -1220,7 +1240,11 @@ defmodule AshOban.Transformers.DefineSchedulers do
               unquote(trigger.debug?)
             )
 
-            case AshOban.lookup_actor(args["actor"], unquote(trigger.actor_persister)) do
+            case AshOban.lookup_actor(
+                args["actor"],
+                unquote(trigger.actor_persister),
+                unquote(Macro.escape(trigger.default_actor))
+              ) do
               {:ok, actor} ->
                 authorize? = AshOban.authorize?()
 
@@ -1402,7 +1426,11 @@ defmodule AshOban.Transformers.DefineSchedulers do
           first = hd(jobs)
           tenant = first.args["tenant"]
 
-          case AshOban.lookup_actor(first.args["actor"], unquote(trigger.actor_persister)) do
+          case AshOban.lookup_actor(
+            first.args["actor"],
+            unquote(trigger.actor_persister),
+            unquote(Macro.escape(trigger.default_actor))
+          ) do
             {:ok, actor} ->
               process_chunk(jobs, actor, authorize?, tenant)
 

--- a/test/ash_oban_test.exs
+++ b/test/ash_oban_test.exs
@@ -41,12 +41,14 @@ defmodule AshObanTest do
                %AshOban.Trigger{name: :dont_fail_oban_job, stream_with: :keyset},
                %AshOban.Trigger{name: :fail_oban_job_custom_backoff, stream_with: :keyset},
                %AshOban.Trigger{name: :snooze_oban_job, stream_with: :keyset},
-               %AshOban.Trigger{name: :cancel_oban_job, stream_with: :keyset}
+               %AshOban.Trigger{name: :cancel_oban_job, stream_with: :keyset},
+               %AshOban.Trigger{name: :process_with_default_actor, stream_with: :keyset},
+               %AshOban.Trigger{name: :scheduler_default_actor, stream_with: :keyset}
              ] = AshOban.Info.oban_triggers(Triggered)
     end
 
     test "nothing happens if no records exist" do
-      assert %{success: 7} = AshOban.Test.schedule_and_run_triggers(Triggered)
+      assert %{success: 8} = AshOban.Test.schedule_and_run_triggers(Triggered)
     end
 
     test "if a record exists, it is processed" do
@@ -220,7 +222,7 @@ defmodule AshObanTest do
       |> Ash.Changeset.for_create(:create)
       |> Ash.create!()
 
-      assert %{success: 9, failure: 1} =
+      assert %{success: 10, failure: 1} =
                AshOban.Test.schedule_and_run_triggers(Triggered)
     end
 
@@ -239,7 +241,7 @@ defmodule AshObanTest do
       |> Ash.Changeset.for_update(:update_triggered)
       |> Ash.update!()
 
-      assert %{success: 10, failure: 0} =
+      assert %{success: 11, failure: 0} =
                AshOban.Test.schedule_and_run_triggers(Triggered)
     end
 
@@ -254,7 +256,9 @@ defmodule AshObanTest do
                %AshOban.Trigger{name: :dont_fail_oban_job},
                %AshOban.Trigger{name: :fail_oban_job_custom_backoff},
                %AshOban.Trigger{name: :snooze_oban_job},
-               %AshOban.Trigger{name: :cancel_oban_job}
+               %AshOban.Trigger{name: :cancel_oban_job},
+               %AshOban.Trigger{name: :process_with_default_actor},
+               %AshOban.Trigger{name: :scheduler_default_actor}
              ] = AshOban.Info.oban_triggers(Triggered)
     end
 
@@ -282,9 +286,13 @@ defmodule AshObanTest do
                  {Oban.Plugins.Cron,
                   [
                     crontab: [
+                      {"0 0 1 1 *",
+                       AshOban.Test.Triggered.AshOban.ActionWorker.SendStaticActor, []},
                       {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.NotifyEachTenant,
                        []},
                       {"0 0 1 1 *", AshOban.Test.Triggered.AshOban.ActionWorker.SayHello, []},
+                      {"* * * * *",
+                       AshOban.Test.Triggered.AshOban.Scheduler.SchedulerStaticActor, []},
                       {"* * * * *",
                        AshOban.Test.Triggered.AshOban.Scheduler.FailObanJobWithCustomBackoff, []},
                       {"* * * * *", AshOban.Test.Triggered.AshOban.Scheduler.DontFailObanJob, []},
@@ -363,6 +371,76 @@ defmodule AshObanTest do
       AshOban.Test.assert_triggered(record, :cancel_oban_job)
 
       assert %{cancelled: 1} = Oban.drain_queue(queue: :triggered_cancel_oban_job)
+    end
+
+    test "trigger with default_actor uses it when no actor is supplied (no persister required)" do
+      record =
+        Triggered
+        |> Ash.Changeset.for_create(:create, %{})
+        |> Ash.create!()
+
+      AshOban.run_trigger(record, :process_with_default_actor)
+
+      assert %{success: 1} = Oban.drain_queue(queue: :triggered_process)
+
+      assert_receive {:actor, %AshOban.Test.ActorPersister.FakeActor{id: 99}}
+    end
+
+    test "scheduled action with default_actor uses it when no actor is supplied (no persister required)" do
+      AshOban.Test.schedule_and_run_triggers({Triggered, :send_default_actor},
+        scheduled_actions?: true
+      )
+
+      assert_receive {:actor, %AshOban.Test.ActorPersister.FakeActor{id: 77}}
+    end
+
+    test "scheduler-fired trigger uses default_actor for record stream and worker action" do
+      Triggered
+      |> Ash.Changeset.for_create(:create, %{number: 999})
+      |> Ash.create!()
+
+      assert %{success: 2} =
+               AshOban.Test.schedule_and_run_triggers({Triggered, :scheduler_default_actor})
+
+      assert_receive {:actor, %AshOban.Test.ActorPersister.FakeActor{id: 42}}
+    end
+
+    test "explicit actor in schedule_and_run_triggers overrides default_actor" do
+      Triggered
+      |> Ash.Changeset.for_create(:create, %{number: 999})
+      |> Ash.create!()
+
+      assert %{success: 2} =
+               AshOban.Test.schedule_and_run_triggers({Triggered, :scheduler_default_actor},
+                 actor: %AshOban.Test.ActorPersister.FakeActor{id: 1}
+               )
+
+      assert_receive {:actor, %AshOban.Test.ActorPersister.FakeActor{id: 1}}
+    end
+
+    test "lookup_actor falls back to default_actor when persister returns {:ok, nil}" do
+      assert {:ok, %AshOban.Test.ActorPersister.FakeActor{id: 5}} =
+               AshOban.lookup_actor(
+                 nil,
+                 AshOban.Test.ActorPersister,
+                 %AshOban.Test.ActorPersister.FakeActor{id: 5}
+               )
+    end
+
+    test "lookup_actor returns persister-resolved actor when stored, ignoring default_actor" do
+      stored = AshOban.Test.ActorPersister.store(%AshOban.Test.ActorPersister.FakeActor{id: 1})
+
+      assert {:ok, %AshOban.Test.ActorPersister.FakeActor{id: 1}} =
+               AshOban.lookup_actor(
+                 stored,
+                 AshOban.Test.ActorPersister,
+                 %AshOban.Test.ActorPersister.FakeActor{id: 99}
+               )
+    end
+
+    test "lookup_actor returns default_actor when no persister is configured" do
+      assert {:ok, %AshOban.Test.ActorPersister.FakeActor{id: 5}} =
+               AshOban.lookup_actor(nil, :none, %AshOban.Test.ActorPersister.FakeActor{id: 5})
     end
   end
 

--- a/test/support/triggered.ex
+++ b/test/support/triggered.ex
@@ -124,6 +124,31 @@ defmodule AshOban.Test.Triggered do
         scheduler_cron false
         worker_module_name AshOban.Test.Triggered.AshOban.Worker.CancelObanJob
       end
+
+      trigger :process_with_default_actor do
+        action :process
+        queue :triggered_process
+        where expr(processed != true)
+        max_attempts 1
+        scheduler_cron false
+        actor_persister :none
+        default_actor %AshOban.Test.ActorPersister.FakeActor{id: 99}
+        worker_read_action :read
+        worker_module_name AshOban.Test.Triggered.AshOban.Worker.ProcessWithStaticActor
+        scheduler_module_name AshOban.Test.Triggered.AshOban.Scheduler.ProcessWithStaticActor
+      end
+
+      trigger :scheduler_default_actor do
+        action :process
+        queue :triggered_process
+        where expr(number == 999 and processed != true)
+        max_attempts 1
+        scheduler_cron "* * * * *"
+        default_actor %AshOban.Test.ActorPersister.FakeActor{id: 42}
+        worker_read_action :read
+        worker_module_name AshOban.Test.Triggered.AshOban.Worker.SchedulerStaticActor
+        scheduler_module_name AshOban.Test.Triggered.AshOban.Scheduler.SchedulerStaticActor
+      end
     end
 
     scheduled_actions do
@@ -140,6 +165,14 @@ defmodule AshOban.Test.Triggered do
 
         worker_module_name AshOban.Test.Triggered.AshOban.ActionWorker.NotifyEachTenant
       end
+
+      schedule :send_default_actor, "0 0 1 1 *" do
+        action :send_actor
+        queue :triggered_say_hello
+        actor_persister :none
+        default_actor %AshOban.Test.ActorPersister.FakeActor{id: 77}
+        worker_module_name AshOban.Test.Triggered.AshOban.ActionWorker.SendStaticActor
+      end
     end
   end
 
@@ -154,7 +187,7 @@ defmodule AshOban.Test.Triggered do
   end
 
   actions do
-    defaults create: [:tenant_id]
+    defaults create: [:tenant_id, :number]
 
     read :read do
       primary? true
@@ -238,6 +271,13 @@ defmodule AshOban.Test.Triggered do
       run fn input, _ ->
         send(self(), {:tenant, input.tenant})
         {:ok, "notified"}
+      end
+    end
+
+    action :send_actor, :string do
+      run fn _input, context ->
+        send(self(), {:actor, context.actor})
+        {:ok, "sent"}
       end
     end
   end


### PR DESCRIPTION
Adds a `default_actor` option to `trigger` and `schedule`, so cron-fired schedulers and worker jobs can run as a fixed actor without requiring an `actor_persister`.

```elixir
trigger :nightly_cleanup do
  action :cleanup
  default_actor %MyApp.SystemActor{id: "system"}
end
```

### Why

Today there's no first-class way for a cron-fired scheduler to run as a specific actor. The cron plugin inserts scheduler jobs with empty args, so `args["actor"]` is `nil` and `lookup_actor/2` resolves to `nil` — failing any `authorize_if actor_present()` policy.

The documented workaround is a custom `AshOban.PersistActor` whose `lookup(nil)` returns a hardcoded actor. That works but means writing `store/lookup` callbacks just to inject a constant, and the persister is global per-trigger rather than per-action.

A `default_actor` on the DSL is a smaller, clearer affordance for the system-actor case.

### How

`AshOban.lookup_actor/2` gains an optional 3rd `default_actor` argument. When the persister (or its absence) resolves to `nil`, the default is returned instead. All generated worker call-sites pass the trigger's `default_actor` through.

Precedence: explicit actor (via persister) > `default_actor` > `nil`.

Static literal only for now (struct or map). Function/MFA form was discussed and deferred.

### Backward compatibility

`lookup_actor/2` callers are unaffected — the 3rd parameter defaults to `nil`, preserving prior behavior. Existing users of the `lookup(nil) -> %SystemActor{}` workaround keep working unchanged.

# Contributor checklist

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies